### PR TITLE
Our annotators found some "unexpected behaviour" when using Arborator: annotated hyphens and en-dashes transform into underscores when saved. This patch series corrects that.

### DIFF
--- a/src/conll.test.ts
+++ b/src/conll.test.ts
@@ -70,6 +70,23 @@ const hyphenInsteadOfUnderscoreLineJson: TokenJson = {
   isGroup: false,
 };
 
+// exclude FORM and LEMMA from hyphen-to-underscore replacement
+// (there could be a literal hyphen in the text!)
+const preserveHyphenInFormLemmaLineConll: string = '1	-	–	upos	_	_	0	deprel	_	_';
+const preserveHyphenInFormLemmaLineJson: TokenJson = {
+  ID: '1',
+  FORM: '-',
+  LEMMA: '–',
+  UPOS: 'upos',
+  XPOS: '_',
+  FEATS: {},
+  HEAD: 0,
+  DEPREL: 'deprel',
+  DEPS: {},
+  MISC: {},
+  isGroup: false,
+};
+
 // checks for "=" symbol is misc or feature field
 const equalSymbolInMiscOrFeatureTokenLine: string = '1	form	lemma	upos	_	person=first=second	_	_	_	_';
 // const hyphenInsteadOfUnderscoreLineConllCorrected: string = '1	form	lemma	upos	_	_	0	deprel	_	_';
@@ -138,6 +155,7 @@ test('_extractTokenTabData', () => {
 test('_tokenLineToJson', () => {
   expect(_tokenLineToJson(tokenLine)).toStrictEqual(tokenJson);
   expect(_tokenLineToJson(hyphenInsteadOfUnderscoreLineConll)).toStrictEqual(hyphenInsteadOfUnderscoreLineJson);
+  expect(_tokenLineToJson(preserveHyphenInFormLemmaLineConll)).toStrictEqual(preserveHyphenInFormLemmaLineJson);
   expect(_tokenLineToJson(equalSymbolInMiscOrFeatureTokenLine)).toStrictEqual(equalSymbolInMiscOrFeatureTokenJson);
   expect(_tokenLineToJson(groupTokenLine)).toStrictEqual(groupTokenJson);
 });

--- a/src/conll.ts
+++ b/src/conll.ts
@@ -55,7 +55,7 @@ export const emptySentenceJson = (): SentenceJson => ({
   treeJson: emptyTreeJson(),
 });
 
-const CONLL_STUCTURE: { [key: number]: { [key: string]: string } } = {
+const CONLL_STRUCTURE: { [key: number]: { [key: string]: string } } = {
   0: { label: 'ID', type: 'str' },
   1: { label: 'FORM', type: 'str' },
   2: { label: 'LEMMA', type: 'str' },
@@ -141,9 +141,9 @@ export const _tokenLineToJson = (tokenLine: string): TokenJson => {
   const splittedTokenLine: string[] = trimmedTokenLine.split('\t');
 
   const tokenJson: TokenJson = emptyTokenJson();
-  for (const tabIndex in CONLL_STUCTURE) {
-    if (CONLL_STUCTURE.hasOwnProperty(tabIndex)) {
-      const tabMeta = CONLL_STUCTURE[tabIndex];
+  for (const tabIndex in CONLL_STRUCTURE) {
+    if (CONLL_STRUCTURE.hasOwnProperty(tabIndex)) {
+      const tabMeta = CONLL_STRUCTURE[tabIndex];
       const tabData = splittedTokenLine[tabIndex];
 
       const label: string = tabMeta['label'];
@@ -216,9 +216,9 @@ export const _tabDataJsonToConll = (tabData: string | number | FeatureJson, type
 export const _tokenJsonToLine = (tokenJson: TokenJson): string => {
   const splittedTokenConll: string[] = [];
 
-  for (const tabIndex in CONLL_STUCTURE) {
-    if (CONLL_STUCTURE.hasOwnProperty(tabIndex)) {
-      const tabMeta = CONLL_STUCTURE[tabIndex];
+  for (const tabIndex in CONLL_STRUCTURE) {
+    if (CONLL_STRUCTURE.hasOwnProperty(tabIndex)) {
+      const tabMeta = CONLL_STRUCTURE[tabIndex];
       const tabLabel: string = tabMeta['label'];
       const tabtype: string = tabMeta['type'];
 

--- a/src/conll.ts
+++ b/src/conll.ts
@@ -117,7 +117,9 @@ export const _tabDictToJson = (featureConll: string): FeatureJson => {
 };
 
 const _normalizeNull = (tokenTabData: string, tabMeta: { [key: string]: string }): string => {
-  if (['-', '–'].includes(tokenTabData))
+  if (["FORM", "LEMMA"].includes(tabMeta['label']))
+    return tokenTabData;
+  else if (['-', '–'].includes(tokenTabData))
     return '_';
   else
     return tokenTabData;

--- a/src/conll.ts
+++ b/src/conll.ts
@@ -116,11 +116,13 @@ export const _tabDictToJson = (featureConll: string): FeatureJson => {
   return featureJson;
 };
 
+const _normalizeNull = (tokenTabData: string, tabMeta: { [key: string]: string }): string => {
+  if (['-', '–'].includes(tokenTabData))
+    return '_';
+  else
+    return tokenTabData;
+}
 export const _extractTokenTabData = (tokenTabData: string, type: string): string | number | FeatureJson => {
-  if (['-', '–'].includes(tokenTabData)) {
-    tokenTabData = '_';
-  }
-
   if (type === 'str') {
     return tokenTabData;
   } else if (type === 'int') {
@@ -144,7 +146,7 @@ export const _tokenLineToJson = (tokenLine: string): TokenJson => {
   for (const tabIndex in CONLL_STRUCTURE) {
     if (CONLL_STRUCTURE.hasOwnProperty(tabIndex)) {
       const tabMeta = CONLL_STRUCTURE[tabIndex];
-      const tabData = splittedTokenLine[tabIndex];
+      const tabData = _normalizeNull(splittedTokenLine[tabIndex], tabMeta);
 
       const label: string = tabMeta['label'];
       const type: string = tabMeta['type'];


### PR DESCRIPTION
The first two patches are clean-up, and make no changes to the code
behaviour. The final patch adds logic to skip NULL value normalisation
for FORM and LEMMA columns, and adds a test to prevent regressions.

All tests pass for all commits. What do you think?

References: <20210617102747.31703-1-nlhowell@gmail.com>